### PR TITLE
removing instagram links

### DIFF
--- a/website/_includes/footer.html
+++ b/website/_includes/footer.html
@@ -73,12 +73,6 @@
               </a>
             </li>
             <li>
-              <a class="anchor" href="https://instagram.com/pactus.blockchain/">
-                <i class="fa-brands fa-fw fa-instagram"></i>
-                {% t dict.community.instagram %}
-              </a>
-            </li>
-            <li>
               <a class="anchor" href="https://t.me/pactusblockchain">
                 <i class="fa-brands fa-fw fa-telegram"></i>
                 {% t dict.community.telegram %}

--- a/website/community/index.md
+++ b/website/community/index.md
@@ -21,12 +21,6 @@ title: dict.community.title
     </a>
   </li>
   <li>
-    <a href="https://instagram.com/pactus.blockchain/">
-      <img alt="Discord" src="{{ site.url }}/assets/images/social_instagram.svg" width="32">
-      {% t dict.community.instagram %}
-    </a>
-  </li>
-  <li>
     <a href="https://t.me/pactusblockchain">
       <img alt="Discord" src="{{ site.url }}/assets/images/social_telegram.svg" width="32">
       {% t dict.community.telegram %}


### PR DESCRIPTION
This PR removes the Instagram links due to the page's inactivity.