### PR TITLE
removing node gossip section

### DIFF
--- a/website/_i18n/ar/user-guides/reduce-network/index.md
+++ b/website/_i18n/ar/user-guides/reduce-network/index.md
@@ -36,10 +36,3 @@ By default, this service is enabled.
 Disabling this service helps reduce traffic usage.
 Keep in mind that new nodes rely on other nodes to be able to sync.
 To disable the node-network service, set `node_network` to `false`.
-
-### Disabling Node-Gossip service
-
-The node-gossip is a type of node that helps the network by broadcasting data
-such as transactions and consensus votes.
-By default, this service is disabled. If you enable this service,
-the network usage of your node will increase.

--- a/website/_i18n/en/user-guides/reduce-network/index.md
+++ b/website/_i18n/en/user-guides/reduce-network/index.md
@@ -36,10 +36,3 @@ By default, this service is enabled.
 Disabling this service helps reduce traffic usage.
 Keep in mind that new nodes rely on other nodes to be able to sync.
 To disable the node-network service, set `node_network` to `false`.
-
-### Disabling Node-Gossip service
-
-The node-gossip is a type of node that helps the network by broadcasting data
-such as transactions and consensus votes.
-By default, this service is disabled. If you enable this service,
-the network usage of your node will increase.

--- a/website/_i18n/zh/user-guides/reduce-network/index.md
+++ b/website/_i18n/zh/user-guides/reduce-network/index.md
@@ -37,9 +37,3 @@ Disabling this service helps reduce traffic usage.
 Keep in mind that new nodes rely on other nodes to be able to sync.
 To disable the node-network service, set `node_network` to `false`.
 
-### Disabling Node-Gossip service
-
-The node-gossip is a type of node that helps the network by broadcasting data
-such as transactions and consensus votes.
-By default, this service is disabled. If you enable this service,
-the network usage of your node will increase.

--- a/website/_i18n/zh/user-guides/reduce-network/index.md
+++ b/website/_i18n/zh/user-guides/reduce-network/index.md
@@ -36,4 +36,3 @@ By default, this service is enabled.
 Disabling this service helps reduce traffic usage.
 Keep in mind that new nodes rely on other nodes to be able to sync.
 To disable the node-network service, set `node_network` to `false`.
-


### PR DESCRIPTION
This PR removes the "Disabling Node-Gossip service" section from the "reducing network" tutorial post